### PR TITLE
Headline links use their title as description

### DIFF
--- a/ox-pandoc.el
+++ b/ox-pandoc.el
@@ -1622,8 +1622,10 @@ holding contextual information."
 
          ((string-prefix-p "citeproc_bib_item" path) ; Rendered citation footnote number
 		  ) ;; leave it alone, it should already be correct
-		 
-         (t                           ; captioned items
+
+         ((eq dest-type 'headline)) ; Headline
+         
+         (t                             ; captioned items
           (setq number (org-export-get-ordinal
                         destination info nil #'org-pandoc--has-caption-p))))
 


### PR DESCRIPTION
Using a headline as a link description, instead of a number.